### PR TITLE
[Feat] Weather 초기 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/minair/config/WebclientConfig.java
+++ b/src/main/java/com/minair/config/WebclientConfig.java
@@ -1,0 +1,20 @@
+package com.minair.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebclientConfig {
+
+    @Bean
+    WebClient webClient() {
+        return WebClient.builder()
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer ->
+                                configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/minair/domain/Weather.java
+++ b/src/main/java/com/minair/domain/Weather.java
@@ -1,0 +1,45 @@
+package com.minair.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Weather {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weather_id")
+    private Long id;
+
+    private LocalDate date;
+    private double temperature;
+    private int weatherCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "city_id")
+    private City city;
+
+    @Builder
+    public Weather(LocalDate date, double temperature, int weatherCode, City city) {
+        this.date = date;
+        this.temperature = temperature;
+        this.weatherCode = weatherCode;
+        this.city = city;
+    }
+}

--- a/src/main/java/com/minair/dto/WeatherInfo.java
+++ b/src/main/java/com/minair/dto/WeatherInfo.java
@@ -1,12 +1,10 @@
 package com.minair.dto;
 
 import lombok.Getter;
-import lombok.ToString;
 
 import java.util.concurrent.ConcurrentHashMap;
 
 @Getter
-@ToString
 public class WeatherInfo {
 
     private ConcurrentHashMap<String, Object> daily;

--- a/src/main/java/com/minair/dto/WeatherInfo.java
+++ b/src/main/java/com/minair/dto/WeatherInfo.java
@@ -1,0 +1,14 @@
+package com.minair.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+@ToString
+public class WeatherInfo {
+
+    private ConcurrentHashMap<String, Object> daily;
+}
+

--- a/src/main/java/com/minair/repository/WeatherRepository.java
+++ b/src/main/java/com/minair/repository/WeatherRepository.java
@@ -1,0 +1,7 @@
+package com.minair.repository;
+
+import com.minair.domain.Weather;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeatherRepository extends JpaRepository<Weather, Long> {
+}

--- a/src/main/java/com/minair/service/WeatherClient.java
+++ b/src/main/java/com/minair/service/WeatherClient.java
@@ -1,0 +1,51 @@
+package com.minair.service;
+
+import com.minair.domain.City;
+import com.minair.dto.WeatherInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDate;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherClient {
+
+    private final WebClient webClient;
+
+    private static final String WEATHER_URI = "https://archive-api.open-meteo.com/v1/archive";
+
+    public WeatherInfo getWeatherInfo(City city, LocalDate startDate, LocalDate endDate) {
+        URI uri = transformUri(city, startDate, endDate);
+        return getWeatherInfo(uri);
+    }
+
+    private URI transformUri(City city, LocalDate startDate, LocalDate endDate) {
+        return UriComponentsBuilder
+                .fromUriString(WEATHER_URI)
+                .queryParam("daily","temperature_2m_mean,weathercode")
+                .queryParam("timezone", "GMT")
+                .queryParam("longitude",city.getLongitude())
+                .queryParam("latitude", city.getLatitude())
+                .queryParam("start_date", startDate)
+                .queryParam("end_date", endDate)
+                .build()
+                .toUri();
+    }
+
+    private WeatherInfo getWeatherInfo(URI uri) {
+        return webClient
+                .get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(WeatherInfo.class)
+                .block();
+    }
+}

--- a/src/main/java/com/minair/service/WeatherService.java
+++ b/src/main/java/com/minair/service/WeatherService.java
@@ -24,6 +24,12 @@ public class WeatherService {
 
     private final WeatherRepository weatherRepository;
 
+    @Transactional
+    public void saveAllLastWeathers(WeatherInfo weatherInfo, City city) {
+        List<Weather> weathers = transformInfoToEntity(weatherInfo, city);
+        weatherRepository.saveAll(weathers);
+    }
+
     private List<Weather> transformInfoToEntity(WeatherInfo weatherInfo, City city) {
         ConcurrentHashMap<String, Object> daily = weatherInfo.getDaily();
         List<String> dailyTimes = (List<String>) daily.get("time");

--- a/src/main/java/com/minair/service/WeatherService.java
+++ b/src/main/java/com/minair/service/WeatherService.java
@@ -1,0 +1,52 @@
+package com.minair.service;
+
+import com.minair.domain.City;
+import com.minair.domain.Weather;
+import com.minair.dto.WeatherInfo;
+import com.minair.repository.WeatherRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+    private final WeatherRepository weatherRepository;
+
+    private List<Weather> transformInfoToEntity(WeatherInfo weatherInfo, City city) {
+        ConcurrentHashMap<String, Object> daily = weatherInfo.getDaily();
+        List<String> dailyTimes = (List<String>) daily.get("time");
+        List<Double> dailyTemperature = (List<Double>) daily.get("temperature_2m_mean");
+        List<LocalDate> times = dailyTimes.stream()
+                .map(time -> LocalDate.parse(time, DateTimeFormatter.ISO_DATE))
+                .collect(Collectors.toList());
+
+        List<Integer> dailyWeatherCodes = (List<Integer>) daily.get("weathercode");
+        List<Weather> weathers = addWeatherEntities(city, dailyTimes, dailyTemperature, times, dailyWeatherCodes);
+        return weathers;
+    }
+
+    private List<Weather> addWeatherEntities(City city, List<String> dailyTimes, List<Double> dailyTemperature, List<LocalDate> times, List<Integer> dailyWeatherCodes) {
+        List<Weather> weathers = new ArrayList<>();
+        for (int i = 0; i < dailyTimes.size(); i++) {
+            weathers.add(Weather.builder()
+                    .date(times.get(i))
+                    .temperature(dailyTemperature.get(i))
+                    .weatherCode(dailyWeatherCodes.get(i))
+                    .city(city)
+                    .build());
+        }
+        return weathers;
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [X]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- Weather 초기 구현

### :: 특이사항
- WebClient 의존성이 추가되었습니다.
- 2020년부터 2022년까지의 과거 데이터를 초기화하기 위한 기능들을 구현하였습니다.
- date : 날짜를 의미하며, yyyy-MM-dd 로 저장됩니다.
- temperature : 각 날짜에 해당하는 평균 기온을 저장합니다.
- weathercode : WMO 코드를 통해 해당 날짜의 날씨가 어땠는지를 확인하는 역할입니다.

### WeatherClient
- openmeteo API를 연결하는 역할의 서비스 계층

### WeatherService
- openmeteo API를 통해 가져온 과거 데이터 값을 저장하거나 응답하는 역할의 서비스 계층
