### PR TITLE
[Feat]: City, Weather 초기 DB 세팅 구현

### DIFF
--- a/src/main/java/com/minair/controller/InitDb.java
+++ b/src/main/java/com/minair/controller/InitDb.java
@@ -1,0 +1,44 @@
+package com.minair.controller;
+
+import com.minair.domain.Location;
+import com.minair.dto.WeatherInfo;
+import com.minair.service.CityService;
+import com.minair.service.WeatherClient;
+import com.minair.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+
+@RestController
+@RequestMapping("api")
+@RequiredArgsConstructor
+@Slf4j
+public class InitDb {
+
+    private final CityService cityService;
+    private final WeatherClient weatherClient;
+    private final WeatherService weatherService;
+
+    @PostMapping("/init-city")
+    public void initCity() {
+        Arrays.stream(Location.values()).map(Location::of)
+                .filter(city -> !cityService.isExistedCity(city))
+                .forEach(cityService::save);
+    }
+
+    @PostMapping("/init-weather")
+    public void initWeather() {
+        LocalDate from = LocalDate.of(2020, 1, 1);
+        LocalDate end = LocalDate.of(2022, 12, 31);
+        cityService.findAll()
+                .forEach(city -> {
+                    WeatherInfo weatherInfo = weatherClient.getWeatherInfo(city, from, end);
+                    weatherService.saveAllLastWeathers(weatherInfo, city);
+                });
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- City, Weather 초기 DB 세팅 구현

### :: 특이사항
- Location에 저장된 정보를 통해 City를 초기화하는 API 구현하였습니다.
- openmeteo에서의 2020~2022년까지의 City에 대한 날씨 정보를 초기화하는 API를 구현하였습니다.
