### PR TITLE
[Feat] 가중치 증가 메서드 구현 및 가중치 랜덤 리팩토링

### DIFF
--- a/src/main/java/com/minair/controller/CitySimilarityController.java
+++ b/src/main/java/com/minair/controller/CitySimilarityController.java
@@ -1,0 +1,27 @@
+package com.minair.controller;
+
+import com.minair.common.response.BaseResponse;
+import com.minair.dto.CitySimilarityResponseDto;
+import com.minair.service.CitySimilarityService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Slf4j
+public class CitySimilarityController {
+
+    private final CitySimilarityService citySimilarityService;
+
+    @PatchMapping("/cities/{cityId}/target-cities/{targetCityId}")
+    public BaseResponse<CitySimilarityResponseDto> clickSimilarity(@PathVariable("cityId") Long cityId,
+                                                                   @PathVariable("targetCityId") Long targetCityId) {
+        CitySimilarityResponseDto responseDto = citySimilarityService.updateWeight(cityId, targetCityId);
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/com/minair/domain/CitySimilarity.java
+++ b/src/main/java/com/minair/domain/CitySimilarity.java
@@ -34,10 +34,15 @@ public class CitySimilarity {
     private City targetCity;
 
     private int weight;
+
     @Builder
     public CitySimilarity(City city, City targetCity, int weight) {
         this.city = city;
         this.targetCity = targetCity;
         this.weight = weight;
+    }
+
+    public void update() {
+        this.weight += 1;
     }
 }

--- a/src/main/java/com/minair/dto/CitySimilarityResponseDto.java
+++ b/src/main/java/com/minair/dto/CitySimilarityResponseDto.java
@@ -1,0 +1,20 @@
+package com.minair.dto;
+
+import com.minair.domain.CitySimilarity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CitySimilarityResponseDto {
+
+    private Long citySimilarityId;
+    private int weight;
+
+    public static CitySimilarityResponseDto of(CitySimilarity citySimilarity) {
+        return CitySimilarityResponseDto.builder()
+                .citySimilarityId(citySimilarity.getId())
+                .weight(citySimilarity.getWeight())
+                .build();
+    }
+}

--- a/src/main/java/com/minair/repository/CitySimilarityRepository.java
+++ b/src/main/java/com/minair/repository/CitySimilarityRepository.java
@@ -5,11 +5,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.List;
 
-
-
 public interface CitySimilarityRepository extends JpaRepository<CitySimilarity, Long> {
+
     @Query("SELECT cs FROM CitySimilarity cs JOIN cs.city c WHERE c.id = :cityId")
-    List<CitySimilarity> findByCityId(@Param("cityId") Long cityId);
+    List<CitySimilarity> findAllByCityId(@Param("cityId") Long cityId);
+
+    @Query("select cs from CitySimilarity cs " +
+            "join cs.city c " +
+            "join cs.targetCity tc " +
+            "where c.id = :cityId and tc.id = :targetCityId")
+    Optional<CitySimilarity> findByCityIdAndTargetCityId(@Param("cityId") Long cityId,
+                                                         @Param("targetCityId") Long targetCityId);
 }


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 가중치 증가 메서드 구현
- 가중치 랜덤 리팩토링

### :: 특이사항
### 🔥 가중치 증가 메서드 구현
- 현재 검색한 도시와 유사 여행지 id를 Path Variable로 받아 weight를 증가시키는 API를 구현하였습니다.

### 🔥 가중치 랜덤 리팩토링
- 중복된 유사 도시가 나오던 점을 Set을 이용하여 해결하였습니다.
- 메서드 분리 및 targetCity로 변환하는 작업을 진행하였습니다.