### PR TITLE
[refactor]: 유사 여행지 추출 함수 개선

### DIFF
--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -85,11 +85,17 @@ public class CitySimilarityService {
         int count = 2;
         double totalWeight = 0.0;
 
+        for (CitySimilarity cs : cities) {
+            double weight = cs.getWeight();
+            calculatedWeights.add(weight);
+            totalWeight += weight;
+        }
+
         for (int i = 0; i < count; i++) {
             double randomValue = random.nextDouble();
             double cumulativeWeight = 0.0;
 
-            normalizeWeights(cities, calculatedWeights, totalWeight);
+            normalizeWeights(calculatedWeights);
 
             for (int j = 0; j < calculatedWeights.size(); j++) {
                 cumulativeWeight += calculatedWeights.get(j);
@@ -103,13 +109,11 @@ public class CitySimilarityService {
 
         return result;
     }
-    private void normalizeWeights(List<CitySimilarity> cities, List<Double> calculatedWeights, double totalWeight){
-        for (CitySimilarity cs : cities) {
-            double weight = cs.getWeight();
-            calculatedWeights.add(weight);
-            totalWeight += weight;
-        }
-
+    private void normalizeWeights(List<Double> calculatedWeights){
+        double totalWeight = 0;
+        for(Double cw: calculatedWeights)
+            totalWeight += cw;
+        
         for (int i = 0; i < calculatedWeights.size(); i++) {
             double normalizedWeight = calculatedWeights.get(i) / totalWeight;
             calculatedWeights.set(i, normalizedWeight);

--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -83,12 +83,10 @@ public class CitySimilarityService {
         Random random = new Random();
 
         int count = 2;
-        double totalWeight = 0.0;
 
         for (CitySimilarity cs : cities) {
             double weight = cs.getWeight();
             calculatedWeights.add(weight);
-            totalWeight += weight;
         }
 
         for (int i = 0; i < count; i++) {

--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -82,7 +82,7 @@ public class CitySimilarityService {
         Set<CitySimilarity> result = new HashSet<>();
         Random random = new Random();
 
-        int count = 5;
+        int count = 2;
         double totalWeight = 0.0;
 
         for (CitySimilarity cs : cities) {
@@ -109,7 +109,7 @@ public class CitySimilarityService {
 
         return result;
     }
-    public List<Double> normalizeWeights(List<Double> calculatedWeights, double totalWeight){
+    private List<Double> normalizeWeights(List<Double> calculatedWeights, double totalWeight){
         for (int i = 0; i < calculatedWeights.size(); i++) {
             double normalizedWeight = calculatedWeights.get(i) / totalWeight;
             calculatedWeights.set(i, normalizedWeight);

--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -46,12 +46,12 @@ public class CitySimilarityService {
 
     public List<CitySimilarity> calculateWeights(Long cityid) {
         List<CitySimilarity> cities = findByCityId(cityid);
-
+        
         List<Double> calculatedWeights = new ArrayList<>();
         List<CitySimilarity> result = new ArrayList<>();
         Random random = new Random();
 
-        int count = 2;
+        int count = 5;
 
         double totalWeight = 0.0;
 
@@ -62,25 +62,29 @@ public class CitySimilarityService {
             totalWeight += weight;
         }
 
-
-        for (int i = 0; i < calculatedWeights.size(); i++) {
-            double normalizedWeight = calculatedWeights.get(i) / totalWeight;
-            calculatedWeights.set(i, normalizedWeight);
-        }
-
-
         for (int i = 0; i < count; i++) {
             double randomValue = random.nextDouble();
             double cumulativeWeight = 0.0;
+
+            normalizeWeights(calculatedWeights, totalWeight);
 
             for (int j = 0; j < calculatedWeights.size(); j++) {
                 cumulativeWeight += calculatedWeights.get(j);
                 if (randomValue < cumulativeWeight) {
                     result.add(cities.get(j));
+                    calculatedWeights.remove(j);
                     break;
                 }
             }
         }
+
         return result;
+    }
+    public List<Double> normalizeWeights(List<Double> calculatedWeights, double totalWeight){
+        for (int i = 0; i < calculatedWeights.size(); i++) {
+            double normalizedWeight = calculatedWeights.get(i) / totalWeight;
+            calculatedWeights.set(i, normalizedWeight);
+        }
+        return calculatedWeights;
     }
 }

--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -101,6 +101,7 @@ public class CitySimilarityService {
                 cumulativeWeight += calculatedWeights.get(j);
                 if (randomValue < cumulativeWeight) {
                     result.add(cities.get(j));
+                    cities.remove(j);
                     calculatedWeights.remove(j);
                     break;
                 }
@@ -113,7 +114,7 @@ public class CitySimilarityService {
         double totalWeight = 0;
         for(Double cw: calculatedWeights)
             totalWeight += cw;
-        
+
         for (int i = 0; i < calculatedWeights.size(); i++) {
             double normalizedWeight = calculatedWeights.get(i) / totalWeight;
             calculatedWeights.set(i, normalizedWeight);

--- a/src/main/java/com/minair/service/CitySimilarityService.java
+++ b/src/main/java/com/minair/service/CitySimilarityService.java
@@ -85,17 +85,11 @@ public class CitySimilarityService {
         int count = 2;
         double totalWeight = 0.0;
 
-        for (CitySimilarity cs : cities) {
-            double weight = cs.getWeight();
-            calculatedWeights.add(weight);
-            totalWeight += weight;
-        }
-
         for (int i = 0; i < count; i++) {
             double randomValue = random.nextDouble();
             double cumulativeWeight = 0.0;
 
-            normalizeWeights(calculatedWeights, totalWeight);
+            normalizeWeights(cities, calculatedWeights, totalWeight);
 
             for (int j = 0; j < calculatedWeights.size(); j++) {
                 cumulativeWeight += calculatedWeights.get(j);
@@ -109,12 +103,17 @@ public class CitySimilarityService {
 
         return result;
     }
-    private List<Double> normalizeWeights(List<Double> calculatedWeights, double totalWeight){
+    private void normalizeWeights(List<CitySimilarity> cities, List<Double> calculatedWeights, double totalWeight){
+        for (CitySimilarity cs : cities) {
+            double weight = cs.getWeight();
+            calculatedWeights.add(weight);
+            totalWeight += weight;
+        }
+
         for (int i = 0; i < calculatedWeights.size(); i++) {
             double normalizedWeight = calculatedWeights.get(i) / totalWeight;
             calculatedWeights.set(i, normalizedWeight);
         }
-        return calculatedWeights;
     }
 }
 


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 가중치 정규화 과정을 normalizeWeights 함수로 별도로 구현하였습니다.
- 추출된 도시는 index를 통해 List에서 제외되며, 다시 정규화를 거쳐 새 도시를 뽑게 됩니다.

### :: 특이사항
- 구조 상 중복하여 뽑지 않기 때문에 집합을 쓸 필요는 없으나, 별 차이가 없어 그대로 두었습니다.
